### PR TITLE
Simple Fix for Null Names (MultiServerChat.cs)

### DIFF
--- a/MultiServerChat/MultiServerChat.cs
+++ b/MultiServerChat/MultiServerChat.cs
@@ -100,7 +100,7 @@ namespace MultiServerChat
             RestHelper.SendChatMessage(args.Player, args.TShockFormattedText);
         }
 
-        private void OnJoin(JoinEventArgs args)
+        private void OnGreetPlayer(JoinEventArgs args)
         {
             if (!Config.DisplayJoinLeave)
                 return;
@@ -109,7 +109,8 @@ namespace MultiServerChat
             if (ply == null)
                 return;
 
-            RestHelper.SendJoinMessage(ply);
+            if (ply.ReceivedInfo)
+                RestHelper.SendJoinMessage(ply);
         }
 
         private void OnLeave(LeaveEventArgs args)
@@ -121,7 +122,8 @@ namespace MultiServerChat
             if (ply == null)
                 return;
 
-            RestHelper.SendLeaveMessage(ply);
+            if (ply.ReceivedInfo)
+                RestHelper.SendLeaveMessage(ply);
         }
     }
 }


### PR DESCRIPTION
Added ReceivedInfo handler. With this handler; 
•If a player failed to connect, it won't show the join message at all.
•The function itself won't be called while player name is not taken(Both join and leave statuses)
OnJoin function replaced with OnGreetPlayer so it won't called before the players name actually taken and prevent null calls.